### PR TITLE
Fix that `RESDATA` / `RESULTDATA` could be `nil` that upsets Geocoder

### DIFF
--- a/lib/geocoder/lookups/olleh.rb
+++ b/lib/geocoder/lookups/olleh.rb
@@ -131,16 +131,16 @@ module Geocoder::Lookup
       case Olleh.check_query_type(query)
       when "geocoding" || "reverse_geocoding"
         return [] if doc['RESDATA']['COUNT'] == 0
-        return doc['RESDATA']["ADDRS"]
+        return doc['RESDATA']["ADDRS"] || []
       when "route_search"
         return [] if doc["RESDATA"]["SROUTE"]["isRoute"] == "false"
-        return doc["RESDATA"]
+        return doc["RESDATA"] || []
       when "convert_coord"
-        return doc['RESDATA']
+        return doc['RESDATA'] || []
       when "addr_step_search"
-        return doc['RESULTDATA']
+        return doc['RESULTDATA'] || []
       when "addr_nearest_position_search"
-        return doc['RESULTDATA']
+        return doc['RESULTDATA'] || []
       else
         []
       end


### PR DESCRIPTION
This fixes the fact that this used to throw exception:

```
> Geocoder::Lookup::Olleh.new.search(Geocoder::Query.new('', px: 22.547786, py: 114.101538, radius: 5000))
Geocoder: HTTP request being made for https://openapi.kt.com/maps/search/AddrNearestPosSearch?params=%7B%22px%22%3A22.547786%2C%22py%22%3A114.101538%2C%22radius%22%3A5000%2C%22timestamp%22%3A%2220150723050709636%22%7D
NoMethodError: undefined method `map' for nil:NilClass
from /app/vendor/bundle/ruby/2.2.0/gems/geocoder-1.2.9/lib/geocoder/lookups/base.rb:47:in `search'
```
